### PR TITLE
fix: handle Windows CJK locale encoding issues in mover.py

### DIFF
--- a/mover.py
+++ b/mover.py
@@ -228,7 +228,15 @@ def decode_and_xor(file_path):
         base64_data = f.read()
         decoded_data = base64.b64decode(base64_data)
         decoded_bytes = bytes(byte ^ ord(XOR_KEY[i % len(XOR_KEY)]) for i, byte in enumerate(decoded_data))
-        return decoded_bytes.decode('utf-8')
+        # The game uses platform default encoding for JSON serialization:
+        # UTF-8 on Android/Linux/macOS, but system locale on Windows (e.g. GBK on Chinese Windows).
+        # Try UTF-8 first, then fall back to the system default encoding.
+        try:
+            return decoded_bytes.decode('utf-8')
+        except UnicodeDecodeError:
+            import locale
+            system_encoding = locale.getpreferredencoding(False)
+            return decoded_bytes.decode(system_encoding)
 
 def encode_and_xor(json_str):
     encoded_bytes = bytes(ord(char) ^ ord(XOR_KEY[i % len(XOR_KEY)]) for i, char in enumerate(json_str))

--- a/mover.py
+++ b/mover.py
@@ -154,14 +154,14 @@ def copy_runs_directory(runs_pc_dir, runs_phone_dir, timezone_offset_hours, dire
             run_files = [filename for filename in os.listdir(pc_char_runs_dir) if os.path.isfile(os.path.join(pc_char_runs_dir, filename))]     
             for file_name in run_files:
                 pc_orig_file_path = os.path.join(pc_char_runs_dir, file_name)
-                with open(pc_orig_file_path, 'r') as f_orig:
+                with open(pc_orig_file_path, 'r', encoding='utf-8') as f_orig:
                     run_data = json.load(f_orig)
 
                 if 'local_time' in run_data:
                     run_data['local_time'] = pc_to_mobile_timestamp(run_data['local_time'], timezone_offset_hours)
 
                 temp_file_path = os.path.join(TMP_PC_PATH, f"pc_{char_folder}_{file_name}")
-                with open(temp_file_path, "w") as f_tmp:
+                with open(temp_file_path, "w", encoding='utf-8') as f_tmp:
                     json.dump(run_data, f_tmp, separators=(',', ':'))
 
                 phone_file_path = path_join_adb(char_folder_phone, file_name)
@@ -205,14 +205,14 @@ def copy_runs_directory(runs_pc_dir, runs_phone_dir, timezone_offset_hours, dire
                     print(f"Failed to pull {file_name} from {phone_file_path}. Error: {e}")
                     continue
                 
-                with open(tmp_file_path, "r") as f:
+                with open(tmp_file_path, "r", encoding='utf-8') as f:
                     run_data = json.load(f)
                 
                 if 'local_time' in run_data:
                     run_data['local_time'] = mobile_to_pc_timestamp(run_data['local_time'], timezone_offset_hours)
                 
                 pc_file_path = os.path.join(pc_char_runs_dir, file_name)
-                with open(pc_file_path, "w") as f:
+                with open(pc_file_path, "w", encoding='utf-8') as f:
                     json.dump(run_data, f, separators=(',', ':'))
                 
                 print(f"Successfully pulled and saved {file_name} to {pc_char_runs_dir}.")
@@ -224,7 +224,7 @@ def copy_runs_directory(runs_pc_dir, runs_phone_dir, timezone_offset_hours, dire
 #    while on mobile they're plaintext json.
 
 def decode_and_xor(file_path):
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding='utf-8') as f:
         base64_data = f.read()
         decoded_data = base64.b64decode(base64_data)
         decoded_bytes = bytes(byte ^ ord(XOR_KEY[i % len(XOR_KEY)]) for i, byte in enumerate(decoded_data))
@@ -244,10 +244,10 @@ def pull_encoded_json(phone_file_path, temp_file_path, pc_file_path):
         return
     
     print(f"Pulling and encoding active run save JSON from {phone_file_path}...")
-    with open(temp_file_path, "r") as f:
+    with open(temp_file_path, "r", encoding='utf-8') as f:
         json_data = json.load(f)
     encoded_data = encode_and_xor(json.dumps(json_data))
-    with open(pc_file_path, "w") as f:
+    with open(pc_file_path, "w", encoding='utf-8') as f:
         f.write(encoded_data)
     print(f"Successfully encoded and saved {os.path.basename(pc_file_path)}.")
 
@@ -308,7 +308,7 @@ def main():
                 
             decoded_str = decode_and_xor(pc_file_path)
             temp_file_path = os.path.join(autosaves_temp_path, autosave_file)
-            with open(temp_file_path, "w") as f:
+            with open(temp_file_path, "w", encoding='utf-8') as f:
                 f.write(decoded_str)
             push_files(autosaves_temp_path, saves_phone_path, [autosave_file], must_exist=True)
     else:


### PR DESCRIPTION
  ## Summary

  - Added `encoding='utf-8'` to all 8 `open()` calls in `mover.py` to prevent Python from using the system default encoding (e.g. GBK/cp936) when
  reading/writing files.
  - Added encoding fallback in `decode_and_xor()`: try UTF-8 first, then fall back to the system locale encoding for XOR-decoded bytes.

  ## Problem

  On Chinese/Japanese/Korean Windows, Python defaults to the system locale encoding (e.g. GBK) for `open()` and byte decoding. This causes two distinct    
  crashes:

  1. **`open()` without explicit encoding**: Reading save files containing bytes invalid in GBK crashes with `UnicodeDecodeError` during `mobile_to_pc`.   
  2. **`decode_and_xor()` hard-coded UTF-8**: The PC game serializes JSON using the platform default encoding — UTF-8 on Android/Linux/macOS, but system   
  locale (e.g. GBK) on Windows. After XOR decryption, calling `.decode('utf-8')` on GBK-encoded bytes fails with `UnicodeDecodeError` during
  `pc_to_mobile`.

  ## Fix

  1. Explicitly specify `encoding='utf-8'` on all 8 `open()` calls. All files handled by this script (JSON run data, autosave files, base64-encoded saves) 
  should be read/written as UTF-8 regardless of OS locale.
  2. In `decode_and_xor()`, wrap the UTF-8 decode in a try/except and fall back to `locale.getpreferredencoding()` when UTF-8 fails, accommodating saves   
  created by the Windows PC game.

  ## Test

  - Verified on Windows 11 (Chinese locale, cp936)
  - `mobile_to_pc`: all files pulled and converted successfully
  - `pc_to_mobile`: all files pushed successfully, game launches without crash on Android
  - Round-trip transfer (PC → mobile → PC) verified with data integrity
